### PR TITLE
Fix gnparser install

### DIFF
--- a/R/install_gnparser.R
+++ b/R/install_gnparser.R
@@ -22,7 +22,7 @@
 #' Alternatively, this argument can take a file path of the zip archive or
 #' tarball of gnparser that has already been downloaded from GitLab,
 #' in which case it will not be downloaded again. The minimum version
-#' is `v1.0.0` because gnparser v1 introduced breaking changes - and 
+#' is `v1.0.0` because gnparser v1 introduced breaking changes - and
 #' we don't support older versions of gnparser here.
 #' @param force Whether to install gnparser even if it has already been
 #' installed. This may be useful when upgrading gnparser.
@@ -40,7 +40,12 @@ install_gnparser = function(version = 'latest', force = FALSE) {
     json <- jsonlite::fromJSON(
       'https://api.github.com/repos/gnames/gnparser/releases')
     version <- json$tag_name[1]
-    urls <- json$assets[[1]]$browser_download_url
+    if (version == "nightly") {
+      version  <- json$tag_name[2]
+      urls <- json$assets[[2]]$browser_download_url
+    } else {
+      urls <- json$assets[[1]]$browser_download_url
+    }
     message('The latest gnparser version is ', version)
   }
 

--- a/tests/testthat/test-install_gnparser.R
+++ b/tests/testthat/test-install_gnparser.R
@@ -1,0 +1,10 @@
+skip_on_cran()
+
+test_that("install_gnparser skip the nightly version", {
+    install_gnparser()
+    json <- jsonlite::fromJSON('https://api.github.com/repos/gnames/gnparser/releases')
+    nightly <- json$tag_name[1]
+    latest <- json$tag_name[2]
+    expect_equal(nightly, "nightly")
+    expect_equal(gn_version()$version, latest)
+})


### PR DESCRIPTION


<!-- Please use a feature branch (i.e., put your work in a new branch that has a name that reflects the feature you are working on; https://docs.gitlab.com/ee/workflow/workflow.html) -->

<!-- If authentication is involved: do not share your username/password, or api keys/tokens in this pull request - most likely the maintainer will have their own equivalent key -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`install_gnparser` cannot parse to the nightly version name of gnparser. This commit implements a change that skips the nightly version name and gets the latest stable release.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

fix #12.

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
Get the development version of `{rgnparser}` and run: `rgnparser::install_gnparser()`

```r
if (!require("remotes")) install.packages("remotes")
if (!require("rgnparser")) install_github("ropensci/rgnparser", force = TRUE)

rgnparser::install_gnparser()
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

